### PR TITLE
print.gbm should handle the absence of cross-validation

### DIFF
--- a/R/print.gbm.R
+++ b/R/print.gbm.R
@@ -86,6 +86,10 @@ print.gbm <- function(x, ... ){
 
    #############################################################################
 
+   if (is.null(x$cv.fitted)) {
+       return(invisible())
+   }
+   
    d <- reconstructGBMdata(x)
    if (x$distribution$name == "multinomial"){
        n.class <- x$num.classes

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -22,3 +22,15 @@ test_that("predicts correctly on unknown levels (issue #18)", {
 
     expect_equal(sum(abs(p)), 0)
 })
+
+test_that("print.gbm works without cross-validation (issue #5)", {
+    df <- data.frame(
+        x = runif(100),
+        y = runif(100),
+        z = sample(0:1, 100, replace = TRUE)
+    )
+
+    trained_gbm <- gbm.fit(df[, c("x", "y")], df$z)
+    
+    expect_null(print(trained_gbm))
+})


### PR DESCRIPTION
Closes gbm-developers#5
