### PR TITLE
horizontal labels to the rel.inf plot

### DIFF
--- a/R/print.gbm.R
+++ b/R/print.gbm.R
@@ -238,7 +238,8 @@ summary.gbm <- function(object,
               horiz=TRUE,
               col=rainbow(cBars,start=3/6,end=4/6),
               names=object$var.names[i[cBars:1]],
-              xlab="Relative influence",...)
+              xlab="Relative influence",
+              las=1,...)
    }
    return(data.frame(var=object$var.names[i],
                      rel.inf=rel.inf[i]))


### PR DESCRIPTION
I know this las=1 can be passed to summary.gbm, but it would be nice to have this out of the box. I dont know why would one ever want to use the vertical labels :)
