### PR TITLE
Added a couple tests and revised getCVgroup

### DIFF
--- a/R/gbmCrossVal.R
+++ b/R/gbmCrossVal.R
@@ -16,7 +16,7 @@ gbmCrossVal <- function(cv.folds, nTrain, n.cores,
                         var.names, response.name, group, lVerbose, keep.data,
                         fold.id) {
   i.train <- 1:nTrain
-  cv.group <- getCVgroup(distribution, class.stratify.cv, y,
+  cv.group <- getCVgroup(distribution$name, class.stratify.cv, y,
                          i.train, cv.folds, group, fold.id)
   ## build the models
   cv.models <- gbmCrossValModelBuild(cv.folds, cv.group, n.cores,

--- a/R/gbmDoFold.R
+++ b/R/gbmDoFold.R
@@ -9,6 +9,7 @@ gbmDoFold <- function(X,
     
     # Handle the final model case separately
     if (X == 0){
+      if (lVerbose) message("Fitting Final Model \n")
       res <- gbm.fit(x,y,
                        offset = offset,
                        distribution = distribution,

--- a/R/getCVgroup.R
+++ b/R/getCVgroup.R
@@ -22,10 +22,11 @@ getCVgroup <- function(
         )
       }
     
-    cv.group <- c(
-      sample(rep(1:cv.folds, length = Zeros))
-    , sample(rep(1:cv.folds, length = Ones))
-    )
+    cv.group <- vector(length = length(i.train))
+    cv.group[y[i.train] == 0] = sample(rep(1:cv.folds, length = Zeros))
+    cv.group[y[i.train] == 1] = sample(rep(1:cv.folds, length = Ones))
+    
+    cv.group
     
   } else if (distribution == "pairwise") {
     

--- a/R/getCVgroup.R
+++ b/R/getCVgroup.R
@@ -1,28 +1,48 @@
-getCVgroup <-
-    # Construct cross-validation groups depending on the type of model to be fit
-function(distribution, class.stratify.cv, y, i.train, cv.folds, group, fold.id){
+# Construct cross-validation groups 
+# depending on the type of model to be fit
 
-    if (distribution$name %in% c( "bernoulli") & class.stratify.cv ){
-        nc <- table(y[i.train]) # Number in each class
-        uc <- names(nc)
-        if (min(nc) < cv.folds){
-            stop( paste("The smallest class has only", min(nc), "objects in the training set. Can't do", cv.folds, "fold cross-validation."))
-        }
-        cv.group <- vector(length = length(i.train))
-        for (i in 1:length(uc)){
-           cv.group[y[i.train] == uc[i]] <- sample(rep(1:cv.folds , length = nc[i]))
-        }
-    } # Close if
-    else if (distribution$name == "pairwise") {
-         # Split into CV folds at group boundaries
-         s <- sample(rep(1:cv.folds, length=nlevels(group)))
-         cv.group <- s[as.integer(group[i.train])]
+getCVgroup <- function(
+  distribution, class.stratify.cv, y
+  , i.train, cv.folds, group, fold.id){
+  
+  if(distribution == "bernoulli" & class.stratify.cv){
+    
+    # Number in each class
+    Ones <- tabulate(y[i.train])
+    Zeros <- length(y[i.train])-Ones
+    
+    smallGroup <- min(c(Ones, Zeros))
+    
+    if(smallGroup < cv.folds){
+      stop(
+        paste("The smallest class has only"
+          ,smallGroup
+          ,"objects in the training set. Can't do"
+          ,cv.folds, "fold cross-validation.")
+        )
       }
-    else if (!is.null(fold.id)) {
-         cv.group <- fold.id
-    }
-    else {
-         cv.group <- sample(rep(1:cv.folds, length=length(i.train)))
-    }
-    cv.group
+    
+    cv.group <- c(
+      sample(rep(1:cv.folds, length = Zeros))
+    , sample(rep(1:cv.folds, length = Ones))
+    )
+    
+  } else if (distribution == "pairwise") {
+    
+    # Split into CV folds at group boundaries
+    s <- sample(rep(1:cv.folds, length=nlevels(group)))
+    cv.group <- s[as.integer(group[i.train])]
+         
+  } else if (!is.null(fold.id)) {
+    
+    cv.group <- fold.id
+    
+  } else {
+    
+    cv.group <- sample(rep(1:cv.folds, length=length(i.train)))
+
+  }
+  
+  cv.group
+  
 }

--- a/tests/testthat/test_basic.R
+++ b/tests/testthat/test_basic.R
@@ -238,13 +238,15 @@ test_that("Conversion of 2 factor Y is successful", {
 
   set.seed(32479)
   g1 <- gbm(y ~ ., data = data.frame(y = NumY, PredX)
-            , distribution = 'bernoulli', verbose = FALSE)
-  rig1 <- relative.influence(g1, n.trees=10)
+            , distribution = 'bernoulli', verbose = FALSE
+            , n.trees = 50)
+  rig1 <- relative.influence(g1, n.trees=50)
   
   set.seed(32479)
   g2 <- gbm(y ~ ., data = data.frame(y = FactY, PredX)
-          , distribution = 'bernoulli', verbose = FALSE)
-  rig2 <- relative.influence(g2, n.trees=10)
+          , distribution = 'bernoulli', verbose = FALSE
+          , n.trees = 50)
+  rig2 <- relative.influence(g2, n.trees=50)
   
   expect_equal(rig1, rig2)
 

--- a/tests/testthat/test_basic.R
+++ b/tests/testthat/test_basic.R
@@ -215,7 +215,8 @@ test_that("relative influence picks out true predictors", {
     cls <- rep(c(0, 1), ea=500) # Class
     X <- data.frame(cbind(X1, X2, cls))
     mod <- gbm(cls ~ ., data= X, n.trees=1000, cv.folds=5,
-               shrinkage=.01, interaction.depth=2, n.cores=1)
+               shrinkage=.01, interaction.depth=2, n.cores=1
+               ,distribution = 'bernoulli')
     ri <- relative.influence(mod, sort.=TRUE, scale.=TRUE)
     
     wh <- names(ri)[1:5]

--- a/tests/testthat/test_basic.R
+++ b/tests/testthat/test_basic.R
@@ -252,3 +252,19 @@ test_that("Conversion of 2 factor Y is successful", {
 
   
 })
+
+
+test_that("Cross Validations", {
+  
+  NumY <- sample(rep(c(0,1), 500), size=1000)
+
+  cvGroup <- getCVgroup('bernoulli', FALSE, NumY, i.train = 1:1000, cv.folds = 4, fold.id = NULL)
+  expect_true(all(table(cvGroup)==250))
+  
+  cvStratified <- getCVgroup('bernoulli', TRUE, NumY, i.train = 1:1000, cv.folds = 4, fold.id = NULL)
+  
+  Strats <- sapply(1:4, function(x){table(NumY[cvStratified == 1])})
+  
+  expect_true(all(Strats == 125))
+  
+})

--- a/tests/testthat/test_ir.measures.R
+++ b/tests/testthat/test_ir.measures.R
@@ -1,0 +1,13 @@
+context("test ir measures")
+
+test_that("area under curve", {
+  
+  AUC1 <- gbm.roc.area(c(0,1,0,1,0,1), c(.5,.85,.5,.85,.25,.25))
+  expect_true(round(AUC1, 4) == .7222)
+  
+  AUC2 <- gbm.roc.area(c(rep(1, 10), rep(0, 10))
+    , c(0.66, 0.63, 0.44, 0.83, 0.22, 0.33, 0.98, 0.45, 0.23, 0.61
+        ,0.73, 0.03, 0.53, 0.58, 0.46, 0.47, 0.22, 0.45, 0.12, 0.42))
+  expect_true(AUC2 == .64)
+  
+})


### PR DESCRIPTION
The main point of this one is for the couple tests that I added but I also reworked some of getCVgroup to make it more efficient. The gains are not massive considering that this function is small but it is an improvement.

```
NumY <- sample(rep(c(0,1), 50000), size=100000)
# New function
system.time(getCVgroup('bernoulli', TRUE, NumY, i.train = 1:100000, cv.folds = 4, fold.id = NULL))
#   user  system elapsed 
#   0.007   0.001   0.008 

# Old Function
system.time(getCVgroupOld(distribution, TRUE, NumY, i.train = 1:100000, cv.folds = 4, fold.id = NULL))
#   user  system elapsed 
#   0.166   0.003   0.169 
```

Also, does the pairwise grouping work how we think it should?  

```
# Split into CV folds at group boundaries
s <- sample(rep(1:cv.folds, length=nlevels(group)))
cv.group <- s[as.integer(group[i.train])]
```
