### PR TITLE
Fix InitF() for the Bernoulli distribution

### DIFF
--- a/src/bernoulli.cpp
+++ b/src/bernoulli.cpp
@@ -75,7 +75,7 @@ void CBernoulli::InitF
         double dDen=0.0;         // denominator
         double dNewtonStep=1.0;  // change
         dInitF = 0.0;
-        while(dNewtonStep > 0.0001)
+        while(std::abs(dNewtonStep) > 0.0001)
         {
             dNum=0.0;
             dDen=0.0;

--- a/src/pairwise.cpp
+++ b/src/pairwise.cpp
@@ -750,14 +750,13 @@ void CPairwise::ComputeLambdas(int iGroup, unsigned int cNumItems, const double*
             ranker.SetRank(j, cRankj);
             ranker.SetRank(i, cRanki);
 	    
+#endif
 	    if (!isfinite(dSwapCost)) {
 	      throw GBM::failure("infinite swap cost");
 	    }
-#endif
 
             if (dSwapCost > 0.0)
             {
-#ifdef NOISY_DEBUG
                 cPairs++;
                 const double dRhoij    = 1.0 / (1.0 + std::exp(adF[i]- adF[j])) ;
                 if (!isfinite(dRhoij)) {
@@ -773,7 +772,6 @@ void CPairwise::ComputeLambdas(int iGroup, unsigned int cNumItems, const double*
 		}
                 adDeriv[i] += dDerivij;
                 adDeriv[j] += dDerivij;
-#endif
             }
         }
     }
@@ -981,8 +979,6 @@ void CPairwise::FitBestConstant
     {
         if (vecpTermNodes[iNode] != NULL)
         {
-            vecpTermNodes[iNode]->dPrediction =
-                vecdNum[iNode];
             if (vecdDenom[iNode] <= 0.0)
             {
                 vecpTermNodes[iNode]->dPrediction = 0.0;


### PR DESCRIPTION
The InitF()'s the Newton method termination condition was wrong: most likely it will finish after one iteration.

IMPACT: After the commit[1], adOffset[] is always not NULL. So the Newton process is applied in all the cases if the Bernoulli distribution is chosen.

[1] https://github.com/entelechie/gbm/commit/b7d6f08faa1a3bcb99a9e3c52251ba8af3eb06e8
