### PR TITLE
Update to modern Rcpp build system

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Imports:
     lattice,
     splines,
     parallel,
-    Rcpp
+    Rcpp (>= 0.11.0)
 Suggests:
     testthat (>= 0.11.0),
     knitr
@@ -25,3 +25,4 @@ Description: Extensions
 License: GPL (>= 2) | file LICENSE
 URL: https://github.com/gbm-developers/gbm
 RoxygenNote: 5.0.1
+LinkingTo: Rcpp

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,0 @@
-## Use the R_HOME indirection to support installations of multiple R version
-PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
-PKG_CXXFLAGS=`$(R_HOME)/bin/Rscript -e "Rcpp:::CxxFlags()"`
-
-

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,0 @@
-
-## Use the R_HOME indirection to support installations of multiple R version
-PKG_LIBS = $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "Rcpp:::LdFlags()") $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
-PKG_CXXFLAGS = $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "Rcpp:::CxxFlags()")


### PR DESCRIPTION
We no longer need Makevars and Makevars.win in modern Rcpp.
