### PR TITLE
Set prediction capping for bernoulli distribution to 10

### DIFF
--- a/src/bernoulli.h
+++ b/src/bernoulli.h
@@ -60,6 +60,7 @@ class CBernoulli : public CDistribution {
   // Private Variables
   //-------------------
   bool terminalnode_capped_;
+  double terminalnode_cap_level_;
 };
 
 #endif  // BERNOULLI_H


### PR DESCRIPTION
This is a somewhat arbitrary limit that in principle should be a parameter, but the warning at a value of 1 does seem over-strict; it'll be scaled by the shrinkage parameter anyway.

@jackstat any thoughts?
