### PR TITLE
Reduce size of tests run on CRAN

### DIFF
--- a/tests/testthat/test-basic.r
+++ b/tests/testthat/test-basic.r
@@ -6,7 +6,9 @@
 ####################
 
 context("some basic checks")
+
 test_that("gaussian works", {
+  skip_on_cran()
   ## Based on example in R package
   
   ## test Gaussian distribution gbm model
@@ -69,7 +71,9 @@ test_that("gaussian works", {
   expect_true(cor(data2$Y, f.predict) > 0.990)
   expect_true(sd(data2$Y-f.predict) < sigma)
 })
+
 test_that("coxph works - efron", {
+  skip_on_cran()
   # Require Surv to be available
   require(survival)
   
@@ -131,7 +135,9 @@ test_that("coxph works - efron", {
   # Use observed sd
   expect_true(sd(data2$f - f.predict) < 0.4)
 })
+
 test_that("coxph works - breslow", {
+    skip_on_cran()
     # Require Surv to be available
     require(survival)
   
@@ -221,6 +227,7 @@ test_that("coxph - runs to completion with train_fraction of 1.0", {
   expect_error(gbmt(Surv(tstart, tstop, death==2) ~ bili + protime + albumin + alk.phos, 
                    data=pbc2, distribution=gbm_dist("CoxPH"), train_params=params_2), NA)
 })
+
 test_that("coxph - runs to completion with train_fraction < 1.0 and cv_folds > 1", {
   ## Needed packages
   require(survival)
@@ -254,6 +261,7 @@ test_that("coxph - runs to completion with train_fraction < 1.0 and cv_folds > 1
   expect_error(gbmt(Surv(tstart, tstop, death==2) ~ bili + protime + albumin + alk.phos, 
                     data=pbc2, distribution=gbm_dist("CoxPH"), train_params=params_2, cv_folds=5), NA)
 })
+
 test_that("coxph cv_folds - runs to completion with start-stop, id'ed and stratified dataset", {
   ## Needed packages
   require(survival)
@@ -286,7 +294,9 @@ test_that("coxph cv_folds - runs to completion with start-stop, id'ed and strati
                      steroids + propylac, data=cgd, 
                     distribution = gbm_dist("CoxPH", strata=cgd$hos.cat), train_params=params_4, cv_folds=10), NA)
 })
+
 test_that("bernoulli works", {
+    skip_on_cran()
     set.seed(1)
 
     # create some data
@@ -337,7 +347,9 @@ test_that("bernoulli works", {
     # Base the validation tests on observed discrepancies
     expect_true(sd(f.new - f.1.predict) < 1.0)
 })
+
 test_that("relative influence picks out true predictors", {
+    skip_on_cran()
     set.seed(1234)
     X1 <- matrix(nrow=1000, ncol=50)
     X1 <- apply(X1, 2, function(x) rnorm(1000)) # Random noise
@@ -359,6 +371,7 @@ test_that("relative influence picks out true predictors", {
     res <- sum(wh %in% paste("V", 51:55, sep = ""))
     expect_equal(res, 5)
 })
+
 test_that("Conversion of 2 factor Y is successful", {
   
   NumY <- sample(c(0, 1), size=1000, replace=TRUE)
@@ -386,6 +399,7 @@ test_that("Conversion of 2 factor Y is successful", {
   
   expect_equal(rig1, rig2)
 })
+
 test_that("Cross Validations group generation - Bernoulli", {
   
   NumY <- sample(rep(c(0,1), 500), size=1000)

--- a/tests/testthat/test-old-api.r
+++ b/tests/testthat/test-old-api.r
@@ -8,8 +8,9 @@
 
 #### GBM ####
 context("Test old API works on basic examples - gbm")
+
 test_that("Gaussian works - gbm", {
-  
+  skip_on_cran()
   ## Based on example in R package
   
   ## test Gaussian distribution gbm model
@@ -82,8 +83,10 @@ test_that("Gaussian works - gbm", {
   expect_true(cor(data2$Y, f.predict) > 0.990)
   expect_true(sd(data2$Y-f.predict) < sigma)
 })
+
 test_that("CoxPH works - efron - gbm", {
-  # Require Surv to be available
+  skip_on_cran()
+  ## Require Surv to be available
   require(survival)
   
   # create some data
@@ -151,7 +154,9 @@ test_that("CoxPH works - efron - gbm", {
   # Use observed sd
   expect_true(sd(data2$f - f.predict) < 0.4)
 })
+
 test_that("CoxPH works - breslow - gbm", {
+  skip_on_cran()
   # Require Surv to be available
   require(survival)
   
@@ -220,6 +225,7 @@ test_that("CoxPH works - breslow - gbm", {
   # Use observed sd
   expect_true(sd(data2$f - f.predict) < 0.4)
 })
+
 test_that("coxph - runs to completion with train.fraction of 1.0", {
   ## Needed packages
   require(survival)
@@ -242,6 +248,7 @@ test_that("coxph - runs to completion with train.fraction of 1.0", {
   expect_error(gbm(Surv(tstart, tstop, death==2) ~ bili + protime + albumin + alk.phos, 
                    data=pbc2, distribution="coxph", train.fraction=1.0, n.trees=500, shrinkage=.01, interaction.depth=3), NA)
 })
+
 test_that("coxph - runs to completion with train.fraction < 1.0 and cv.folds > 1", {
   ## Needed packages
   require(survival)
@@ -268,6 +275,7 @@ test_that("coxph - runs to completion with train.fraction < 1.0 and cv.folds > 1
   expect_error(gbm(Surv(tstart, tstop, death==2) ~ bili + protime + albumin + alk.phos, 
                    data=pbc2, distribution="coxph", train.fraction=0.8, n.trees=500, shrinkage=.01, cv.folds=5, interaction.depth=3), NA)
 })
+
 test_that("coxph cv.folds - runs to completion with start-stop, id'ed and stratified dataset", {
   ## Needed packages
   require(survival)
@@ -290,8 +298,9 @@ test_that("coxph cv.folds - runs to completion with start-stop, id'ed and strati
                      steroids + propylac, data=cgd, obs.id=cgd$id,
                    train.fraction=0.8, n.trees=500, strata= cgd$hos.cat, distribution = "coxph", shrinkage=.01, interaction.depth=3, cv.folds=10), NA)
 })
+
 test_that("Bernoulli works - gbm", {
-  
+  skip_on_cran()  
   set.seed(1)
   
   # create some data
@@ -351,6 +360,7 @@ test_that("Bernoulli works - gbm", {
   # Base the validation tests on observed discrepancies
   expect_true(sd(f.new - f.1.predict) < 1.0)
 })
+
 test_that("relative influence picks out true predictors", {
   set.seed(1234)
   X1 <- matrix(nrow=1000, ncol=50)
@@ -397,7 +407,7 @@ test_that("Conversion of 2 factor Y is successful", {
 #### GBM.FIT ####
 context("Test old API works on basic examples - gbm.fit")
 test_that("Gaussian works - gbm.fit", {
-  
+  skip_on_cran()
   ## Based on example in R package
   
   ## test Gaussian distribution gbm model
@@ -467,7 +477,9 @@ test_that("Gaussian works - gbm.fit", {
   expect_true(cor(Y, f.predict) > 0.990)
   expect_true(sd(Y-f.predict) < sigma)
 })
+
 test_that("CoxPH works - efron - gbm", {
+  skip_on_cran()
   # Require Surv to be available
   require(survival)
   
@@ -531,7 +543,9 @@ test_that("CoxPH works - efron - gbm", {
   # Use observed sd
   expect_true(sd(f - f.predict) < 0.4)
 })
+
 test_that("CoxPH works - breslow - gbm", {
+  skip_on_cran()
   # Require Surv to be available
   require(survival)
   
@@ -595,7 +609,9 @@ test_that("CoxPH works - breslow - gbm", {
   # Use observed sd
   expect_true(sd(f - f.predict) < 0.4)
 })
+
 test_that("Bernoulli works - gbm", {
+  skip_on_cran()
   
   set.seed(1)
   

--- a/tests/testthat/test-relative-influence.r
+++ b/tests/testthat/test-relative-influence.r
@@ -138,6 +138,7 @@ test_that("Error thrown if sort_it not logical", {
   expect_error(relative_influence(fit, sort_it = NA))
   expect_error(relative_influence(fit, sort_it = c(TRUE, FALSE)))
 })
+
 test_that("Error thrown if num_trees exceeds number in fit", {
 ## Based on example in R package
 
@@ -473,7 +474,7 @@ test_that("Error thrown if not GBMFit object", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=200, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -486,6 +487,7 @@ test_that("Error thrown if not GBMFit object", {
   # Then permutation_relative_influence throws an error
   expect_error(permutation_relative_influence(fit, 100))
 })
+
 test_that("Error thrown if rescale not logical", {
   ## Based on example in R package
   
@@ -517,7 +519,7 @@ test_that("Error thrown if rescale not logical", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=200, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -561,7 +563,7 @@ test_that("Error thrown if sort_it not logical", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=200, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -574,6 +576,7 @@ test_that("Error thrown if sort_it not logical", {
   expect_error(permutation_relative_influence(fit, 100, sort_it = NA))
   expect_error(permutation_relative_influence(fit, 100, sort_it = c(TRUE, FALSE)))
 })
+
 test_that("Error thrown if num_trees exceeds number in fit", {
   ## Based on example in R package
   
@@ -605,7 +608,7 @@ test_that("Error thrown if num_trees exceeds number in fit", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=200, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -616,6 +619,7 @@ test_that("Error thrown if num_trees exceeds number in fit", {
   # Then relative_influence throws an error
   expect_error(permutation_relative_influence(fit, num_trees=length(fit$trees)+100))
 })
+
 test_that("Error thrown if num_trees not a positive integer", {
   ## Based on example in R package
   
@@ -647,7 +651,7 @@ test_that("Error thrown if num_trees not a positive integer", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=200, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -692,7 +696,7 @@ test_that("Perm Relative influence can run with a specified num_trees", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=200, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -733,7 +737,7 @@ test_that("can run with rescale and sorting", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=200, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N, num_features=6)
   dist <- gbm_dist("Gaussian")
   

--- a/tests/testthat/test-summary-and-print.r
+++ b/tests/testthat/test-summary-and-print.r
@@ -28,7 +28,7 @@ test_that("print_perf_measures defaults to total number of iterations if train_f
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -41,6 +41,7 @@ test_that("print_perf_measures defaults to total number of iterations if train_f
   expect_equal(best_iter, params$num_trees)
   
 })
+
 test_that("print_perf_measures calculates the performance using test if train_fraction < 1", {
   # Given a "correct" GBMFit object - train_fraction < 1
   set.seed(1)
@@ -63,7 +64,7 @@ test_that("print_perf_measures calculates the performance using test if train_fr
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -97,7 +98,7 @@ test_that("print_perf_measures returns the performance using cv if fit is cross-
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -131,7 +132,7 @@ test_that("print_iters_and_dist does not throw error when passed a GBMFit object
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -163,7 +164,7 @@ test_that("print_confusion_matrix does not throw error when passed a GBMFit obje
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -195,7 +196,7 @@ test_that("binary_response_conf_matrix does not throw error when called correctl
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -227,7 +228,7 @@ test_that("pseudo_r_squared does not throw error when passed correct inputs", {
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -259,7 +260,7 @@ test_that("pseudo_r_squared is same for all dists except Gaussian", {
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -307,7 +308,7 @@ test_that("print_perf_measures throws error if passed an object other than GBMFi
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -343,7 +344,7 @@ test_that("print_iters_and_dist throws error if passed an object other than GBMF
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -379,7 +380,7 @@ test_that("print_confusion_matrix throws error if passed an object other than GB
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -415,7 +416,7 @@ test_that("summary.GBMFit throws error if cBars is not a whole number > 1", {
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -453,7 +454,7 @@ test_that("summary.GBMFit throws error if num_trees is not a whole number > 1", 
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -491,7 +492,7 @@ test_that("summary.GBMFit throws error if plot_it is not a logical", {
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -529,7 +530,7 @@ test_that("summary.GBMFit throws error if normalize is not a logical", {
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -568,7 +569,7 @@ test_that("Print method on GBMFit object runs without error", {
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -604,7 +605,7 @@ test_that("Summary method on GBMFit object runs without error", {
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -640,7 +641,7 @@ test_that("Summary method returns data.frame of variables and relative influence
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,
@@ -682,7 +683,7 @@ test_that("Summary method returns variables and relative influence ordered by re
   offset <- rep(0, N)
   
   # Set up for new API
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=30, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   dist <- gbm_dist("Bernoulli")
   fit <- gbmt(Y~X1+X2+X3, data=data, distribution=dist, weights=w, offset=offset,

--- a/tests/testthat/test-to-old-gbm.r
+++ b/tests/testthat/test-to-old-gbm.r
@@ -6,6 +6,7 @@
 ####################
 
 context("Testing conversion of GBMFit to gbm object")
+
 test_that("to_old_gbm produces an object with the right class", {
   set.seed(1)
   
@@ -34,7 +35,7 @@ test_that("to_old_gbm produces an object with the right class", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=20, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -72,7 +73,7 @@ test_that("to_old_gbm output has correct fields", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=20, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -117,7 +118,7 @@ test_that("to_old_gbm gives correct message on calling", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=20, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -127,6 +128,7 @@ test_that("to_old_gbm gives correct message on calling", {
   # Then correct message given
   expect_message(to_old_gbm(fit), "Converted to old gbm object - this will not work with new packages functions")
 })
+
 test_that("to_old_gbm has data if keep_gbm_data was specified and it is correct", {
   set.seed(1)
   
@@ -155,7 +157,7 @@ test_that("to_old_gbm has data if keep_gbm_data was specified and it is correct"
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=20, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -169,6 +171,7 @@ test_that("to_old_gbm has data if keep_gbm_data was specified and it is correct"
   expect_equal(to_old_gbm(fit)$data$offset, fit$gbm_data_obj$offset)
   expect_true(is.na(to_old_gbm(fit)$data$Misc))
 })
+
 test_that("to_old_gbm has correct default prior.node.coeff.var if not CoxPH", {
   set.seed(1)
   
@@ -197,7 +200,7 @@ test_that("to_old_gbm has correct default prior.node.coeff.var if not CoxPH", {
   
   
   # Set up for new API
-  params <- training_params(num_trees=2000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=20, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.005, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=6)
   dist <- gbm_dist("Gaussian")
   
@@ -207,6 +210,7 @@ test_that("to_old_gbm has correct default prior.node.coeff.var if not CoxPH", {
   # prior.node.coeff.var has correct default value
   expect_equal(to_old_gbm(fit)$prior.node.coeff.var, 1000)
 })
+
 test_that("to_old_gbm has correct data and time ordering for CoxPH fit", {
   # Require Surv to be available
   require(survival)
@@ -235,7 +239,7 @@ test_that("to_old_gbm has correct data and time ordering for CoxPH fit", {
   
   # Put into new API
   dist <- gbm_dist("CoxPH", prior_node_coeff_var=10)
-  params <- training_params(num_trees=3000, interaction_depth=3, min_num_obs_in_node=10, 
+  params <- training_params(num_trees=20, interaction_depth=3, min_num_obs_in_node=10, 
                             shrinkage=0.001, bag_fraction=0.5, id=seq(nrow(data)), num_train=N/2, num_features=3)
   
   # fit initial model
@@ -279,7 +283,7 @@ test_that("to_old_gbm has group ordering for Pairwise fit", {
   
   data <- data.frame(Y, query=query, X1, X2, X3)
   dist <- gbm_dist("Pairwise", metric="ndcg", group="query")
-  params <- training_params(num_trees = 2000, num_train = nrow(data), id=seq_len(nrow(data)),
+  params <- training_params(num_trees = 20, num_train = nrow(data), id=seq_len(nrow(data)),
                             interaction_depth = 3)
   
   fit <- gbmt(Y~X1+X2+X3,          # formula


### PR DESCRIPTION
Decrease number of trees and add in `skip_on_cran()` directives to make tests less scary
